### PR TITLE
Add Working Language

### DIFF
--- a/about/contributing.md
+++ b/about/contributing.md
@@ -16,3 +16,18 @@ Please keep the following in mind:
   will not be accepted / merged.
 
 Thanks for your help in making MagicMirror² better!
+
+## Working Language
+
+To ensure inclusivity, collaboration, and accessibility for contributors from all around the world, we have chosen English as the working language for this project. Here are the key reasons behind this decision:
+
+1. Global Accessibility: English is widely recognized and understood, enabling a diverse group of contributors to participate, share ideas, and collaborate effectively without language barriers.
+2. Uniform Documentation: Using English for documentation ensures that all project materials are consistent and comprehensible to the majority of developers, regardless of their native language.
+3. Broader Community Engagement: By using a common language, we can engage with a broader community, attracting talent and contributions from various regions and backgrounds.
+4. Resource Availability: Most technical resources, tutorials, and libraries are available in English, providing contributors with a wealth of information and tools to support their work.
+
+We understand that choosing English as the working language is not the perfect solution for everyone, as it may present challenges for non-English speakers. However, it is the best compromise to ensure effective communication and collaboration across our diverse and global community.
+
+If you are not comfortable with English and cannot use translation tools, please feel free to use your native language in the forum. However, please keep in mind that asking questions in English is more likely to get you help quickly.
+
+We appreciate your understanding and cooperation in using English as the working language. Together, let's build something amazing!

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -6,6 +6,7 @@
     "apikey",
     "clientonly",
     "iconset",
+    "inclusivity",
     "infobars",
     "LXDE",
     "lxpanel",


### PR DESCRIPTION
I would like to propose this update to our Contributing Guidelines regarding the working language. While English has always been our de facto working language, it hasn't been explicitly stated in our documentation. Recently, we have received contributions in other languages, which highlighted the need for clearer guidelines to ensure smooth communication and collaboration within our diverse community.

Side note: I personally struggle with English myself, and in an ideal world, I would choose another language as working language (Esperanto, of course). However, I accept the reality and see this as the most viable solution for our community.