### PR TITLE
replace `npm start` with `npm run start`

### DIFF
--- a/configuration/autostart.md
+++ b/configuration/autostart.md
@@ -44,7 +44,7 @@ Add the following lines:
 
 ```shell
 cd ./MagicMirror
-DISPLAY=:0 npm start
+DISPLAY=:0 npm run start
 ```
 
 Save and close, using the commands `CTRL-O` and `CTRL-X`. Now make sure the

--- a/configuration/introduction.md
+++ b/configuration/introduction.md
@@ -84,7 +84,7 @@ By default, you would use config.js with a bash script (mm.sh):
 
 ```bash
 cd ~/MagicMirror
-npm start
+npm run start
 ```
 
 To use the 2nd configuration file, use a bash script like this (mm2.sh):
@@ -92,7 +92,7 @@ To use the 2nd configuration file, use a bash script like this (mm2.sh):
 ```bash
 cd ~/MagicMirror
 export MM_CONFIG_FILE=config/config2.js
-npm start
+npm run start
 ```
 
 To change the port:
@@ -100,7 +100,7 @@ To change the port:
 ```bash
 cd ~/MagicMirror
 export MM_PORT=8081
-npm start
+npm run start
 ```
 
 You can run `npm run config:check` on your 2nd configuration file by typing the
@@ -182,7 +182,7 @@ cd ~/MagicMirror
 export MY_ADDRESS=localhost
 export MY_PORT=8080
 export MY_HTTPS=false
-npm start
+npm run start
 ```
 
 ### Using `electronOptions`
@@ -217,7 +217,7 @@ Starting Script 1 (mm.sh):
 
 ```bash
 cd ~/MagicMirror
-npm start
+npm run start
 ```
 
 Starting Script 2 (mm2.sh):
@@ -225,7 +225,7 @@ Starting Script 2 (mm2.sh):
 ```bash
 cd ~/MagicMirror
 export MM_CONFIG_FILE=config/config2.js
-npm start
+npm run start
 ```
 
 Configuration file 1 (config.js):

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -107,14 +107,14 @@ Command Prompt:
 
 Otherwise the screen will stay black when starting the software.
 
-**Step 7:** In Windows you must use `npm start:windows` instead of `npm start`.
+**Step 7:** In Windows you must use `npm run start:windows` instead of `npm run start`.
 
 ## Usage
 
 Note the following:
 
-- `npm start` does **not** work via SSH. But you can use
-  `DISPLAY=:0 nohup npm start &` instead. \
+- `npm run start` does **not** work via SSH. But you can use
+  `DISPLAY=:0 nohup npm run start &` instead. \
   This starts the mirror on the remote display.
 - If you want to debug on your Raspberry Pi you can use `npm run start:dev`
   which will start MM with _Dev Tools_ enabled.


### PR DESCRIPTION
fixes #303 

I replaced all occurrences, not only the one concerning windows, I think it is clearer not to use the abbreviation `npm start` in the docs.