### PR TITLE
update automerge workflow

### DIFF
--- a/.github/workflows/autoupdate_develop.yaml
+++ b/.github/workflows/autoupdate_develop.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.REPO_PUSH_TOKEN }}
     - name: Merge master back to develop
       run: |
         git config --local user.email "actions@github.com"


### PR DESCRIPTION
see #311 

use secret which has contents rw access for pulling/pushing

The used secret must be approved by an org admin @rejas (I requested twice, need approval for latest request, did delete the first one)
It must be renewed yearly