### PR TITLE
Add reference to Deepwiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ MagicMirror² focuses on a modular plugin system and uses
 [Electron](https://www.electronjs.org/) as an application wrapper. So no more
 web server or browser installs necessary!
 
+## Further reading
+
+Looking for a deeper understanding or a different perspective? Deepwiki offers a
+concise architecture map and cross‑repo insights that complement this
+documentation:
+[Deepwiki overview of MagicMirror](https://deepwiki.com/MagicMirrorOrg/MagicMirror/).
+This is an independent, third-party documentation and analysis tool (not
+affiliated with the MagicMirror team).
+
 <p style="text-align: center">
 	<a href="https://forum.magicmirror.builders/topic/728/magicmirror-is-voted-number-1-in-the-magpi-top-50"><img src="https://magicmirror.builders/img/magpi-best-watermark-custom.png" width="150" alt="MagPi Top 50"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Looking for a deeper understanding or a different perspective? Deepwiki offers a
 concise architecture map and cross‑repo insights that complement this
 documentation:
 [Deepwiki overview of MagicMirror](https://deepwiki.com/MagicMirrorOrg/MagicMirror/).
-This is an independent, third-party documentation and analysis tool (not
-affiliated with the MagicMirror team).
+
+This independent, third-party, AI generated documentation and analysis is not
+authored by the MagicMirror team — use it with a critical eye.
 
 <p style="text-align: center">
 	<a href="https://forum.magicmirror.builders/topic/728/magicmirror-is-voted-number-1-in-the-magpi-top-50"><img src="https://magicmirror.builders/img/magpi-best-watermark-custom.png" width="150" alt="MagPi Top 50"></a>

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "Deepwiki",
     "anyfileorfolder",
     "apikey",
     "Autorestart",

--- a/development/introduction.md
+++ b/development/introduction.md
@@ -67,3 +67,13 @@ same time.
   can be used by the core module script. For example:
   _modulename/css/modulename.css_ would be a good path for your additional
   module styles.
+
+## Further reading
+
+Deepwiki provides a complementary, high‑level view of MagicMirror — architecture
+map, component interactions, and codebase hot spots — it may help you to gain a
+deeper understanding, spot extension points, and debug faster. See the
+[Deepwiki overview of MagicMirror](https://deepwiki.com/MagicMirrorOrg/MagicMirror/).
+
+This is an independent, third-party documentation and analysis tool (not
+affiliated with the MagicMirror team).

--- a/development/introduction.md
+++ b/development/introduction.md
@@ -75,5 +75,5 @@ map, component interactions, and codebase hot spots — it may help you to gain 
 deeper understanding, spot extension points, and debug faster. See the
 [Deepwiki overview of MagicMirror](https://deepwiki.com/MagicMirrorOrg/MagicMirror/).
 
-This is an independent, third-party documentation and analysis tool (not
-affiliated with the MagicMirror team).
+This independent, third-party, AI generated documentation and analysis is not
+authored by the MagicMirror team — use it with a critical eye.

--- a/modules/introduction.md
+++ b/modules/introduction.md
@@ -21,3 +21,12 @@ If you want to build your own modules, check out the
 and don't forget to add it to the
 [wiki](https://github.com/MagicMirrorOrg/MagicMirror/wiki) and the
 [forum](https://forum.magicmirror.builders/category/7/showcase)!
+
+## Further reading
+
+For a big‑picture view of how modules plug into the core (APIs, lifecycle,
+communication paths), see Deepwiki’s project overview — great for planning
+integrations and troubleshooting:
+[Deepwiki overview of MagicMirror](https://deepwiki.com/MagicMirrorOrg/MagicMirror/).
+This is an independent, third-party documentation and analysis tool (not
+affiliated with the MagicMirror team).

--- a/modules/introduction.md
+++ b/modules/introduction.md
@@ -28,5 +28,6 @@ For a big‑picture view of how modules plug into the core (APIs, lifecycle,
 communication paths), see Deepwiki’s project overview — great for planning
 integrations and troubleshooting:
 [Deepwiki overview of MagicMirror](https://deepwiki.com/MagicMirrorOrg/MagicMirror/).
-This is an independent, third-party documentation and analysis tool (not
-affiliated with the MagicMirror team).
+
+This independent, third-party, AI generated documentation and analysis is not
+authored by the MagicMirror team — use it with a critical eye.


### PR DESCRIPTION
I consider Deepwiki to be a very interesting project and think that it can be a good addition to our official documentation. Therefore, I propose mentioning it in the documentation.

See: https://deepwiki.com/MagicMirrorOrg/MagicMirror.